### PR TITLE
feat: add lambda functions (closures)

### DIFF
--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -137,10 +137,11 @@ impl Display for Expr {
     }
 }
 
-impl<A, B> Display for ExprKind<A, B>
+impl<A, B, LambdaFun> Display for ExprKind<A, B, LambdaFun>
 where
     A: Display,
     B: Display,
+    LambdaFun: Display,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -213,6 +214,9 @@ where
             }
             ExprKind::MemberAccess { target, member } => {
                 write!(f, "{}.{}", target, member)
+            }
+            ExprKind::Lambda(fun) => {
+                write!(f, "{}", fun)
             }
         }
     }
@@ -306,6 +310,20 @@ impl Display for TypedStmt {
     }
 }
 
+impl Display for TypedFunDecl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "fun {}(", self.name)?;
+        let parameters = self
+            .parameters
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<String>>()
+            .join(", ");
+        write!(f, "{})", parameters)?;
+        write!(f, ": {} {{\n{}\n}}", self.return_type, self.body)
+    }
+}
+
 impl Display for TypedExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.node)
@@ -315,20 +333,8 @@ impl Display for TypedExpr {
 impl Display for TypedDeclKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            TypedDeclKind::FunDecl(TypedFunDecl {
-                name,
-                parameters,
-                return_type,
-                body,
-            }) => {
-                write!(f, "fun {}(", name)?;
-                let parameters = parameters
-                    .iter()
-                    .map(|p| p.to_string())
-                    .collect::<Vec<String>>()
-                    .join(", ");
-                write!(f, "{})", parameters)?;
-                write!(f, ": {} {{\n{}\n}}", return_type, body)
+            TypedDeclKind::FunDecl(fun) => {
+                write!(f, "{}", fun)
             }
             TypedDeclKind::VarDecl(v) => {
                 write!(f, "{}", v)

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -255,4 +255,10 @@ fn main() = foo()
         assert_eq!(imports[1].imported_ids, vec!["bar", "baz"]);
         assert_eq!(imports[1].path, "./baz");
     }
+
+    #[test]
+    fn test_lambdas() {
+        assert!(parse_ast("fn foo() = |a: Int| { a + 1 }").is_ok());
+        assert!(parse_ast("fn foo(lst) = lst.map(|x| { x * 2 })").is_ok());
+    }
 }

--- a/src/frontend/type_ast.rs
+++ b/src/frontend/type_ast.rs
@@ -287,6 +287,7 @@ impl Expr {
             ExprKind::Boolean(v) => ExprKind::Boolean(v),
             ExprKind::Identifier(v) => ExprKind::Identifier(v),
             ExprKind::Char(v) => ExprKind::Char(v),
+            ExprKind::Lambda(fundecl) => ExprKind::Lambda(fundecl.type_ast()?),
         };
 
         Ok(TypedExpr {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -40,6 +40,7 @@ match {
     "]" => RBRACKET,
     "{" => LBRACE,
     "}" => RBRACE,
+    "|" => PIPE,
     "true" => TRUE,
     "false" => FALSE,
     "fn" => FN,
@@ -225,7 +226,7 @@ Stmt: Stmt = {
 Expr: Expr = {
     #[precedence(level="0")]
     Term,
-    #[precedence(level="1")] #[assoc(side="left")]
+    #[precedence(level="2")] #[assoc(side="left")]
     <l: @L> <lhs: Expr> <opcode: BinOpPrec1> <rhs: Expr> <r: @R> => {
         Expr {
             node: ExprKind::Binary{op: Operator::from(opcode.as_str()), lhs: Box::new(lhs), rhs: Box::new(rhs)},
@@ -233,7 +234,7 @@ Expr: Expr = {
             inferred_ty: None,
         }
     },
-    #[precedence(level="2")] #[assoc(side="left")]
+    #[precedence(level="3")] #[assoc(side="left")]
     <l: @L> <lhs: Expr> <opcode: BinOpPrec2> <rhs: Expr> <r: @R> => {
         Expr {
             node: ExprKind::Binary{op: Operator::from(opcode.as_str()), lhs: Box::new(lhs), rhs: Box::new(rhs)},
@@ -241,7 +242,7 @@ Expr: Expr = {
             inferred_ty: None,
         }
     },
-    #[precedence(level="3")] #[assoc(side="left")]
+    #[precedence(level="4")] #[assoc(side="left")]
     <l: @L> <lhs: Expr> <opcode: BinOpPrec3> <rhs: Expr> <r: @R> => {
         Expr {
             node: ExprKind::Binary{op: Operator::from(opcode.as_str()), lhs: Box::new(lhs), rhs: Box::new(rhs)},
@@ -283,6 +284,7 @@ Term: Expr = {
     Compound => <>,
     Match => <>,
     StructInitializer => <>,
+    LambdaExpr => <>,
 }
 
 Compound: Expr = {
@@ -406,6 +408,22 @@ IfExpr: Expr = {
 IdentifierExpr: Expr = {
     <l: @L> <id: Identifier> <r: @R> => Expr {
         node: ExprKind::Identifier(id),
+        location: Location::new(l, r),
+        inferred_ty: None,
+    }
+}
+
+LambdaExpr: Expr = {
+    <l: @L> PIPE <parameters: MaybeTypedIdentifiers> PIPE <return_type: (COLON <WrittenType>)?> <body: Compound> <r: @R> => Expr {
+        node: ExprKind::Lambda (FunDecl {
+            name: "AnonymousFunction".to_string(),
+            parameters,
+            return_type,
+            body: Box::new(body),
+            inferred_parameters: None,
+            inferred_return_type: None,
+            generics: vec![],
+        }),
         location: Location::new(l, r),
         inferred_ty: None,
     }

--- a/stdlib/list.mjl
+++ b/stdlib/list.mjl
@@ -48,17 +48,6 @@ impl List[T] {
         Nil => Nil(),
     }
 
-    fn filter(fun: (T) => Bool): List[T] = match self {
-        Cons(head, tail) => {
-            if fun(head) {
-                Cons(head, tail.filter(fun))
-            } else {
-                tail.filter(fun)
-            }
-        },
-        Nil => Nil(),
-    }
-
     fn fold_right[Q](init: Q, op: (T, Q) => Q): Q = match self {
         Cons(head, tail) => op(head, tail.fold_right(init, op)),
         Nil => init,
@@ -68,6 +57,14 @@ impl List[T] {
         Cons(head, tail) => tail.fold_left(op(head, init), op),
         Nil => init,
     }
+
+    fn filter(fun: (T) => Bool): List[T] = self.fold_left(Nil(), |x, acc| {
+        if fun(x) {
+            Cons(x, acc)
+        } else {
+            acc
+        }
+    })
 
     fn reverse(): List[T] = self.fold_left(Nil(), Cons)
 }


### PR DESCRIPTION
The chosen syntax is `|par: type|: retType { <expr> }`. This is for an ease of parsing implementation and to prevent LR conflicts. Some day down the road we would like it to change to `(par: Type): RetType => <expr>`